### PR TITLE
Änderung im Ablauf: Neu Diplomausstellung auch im Frühling (ab HS23)

### DIFF
--- a/ProStudCreator/Ablauf.aspx
+++ b/ProStudCreator/Ablauf.aspx
@@ -6,7 +6,7 @@
         <ol>
             <li>Passe die grau hinterlegte Gewichtung im <a href="Content/Bewertungsbogen Projekte 5 und 6.xlsx" class="xls">Bewertungsbogen</a> an.
             </li>
-            <li>Schreibe bei Semesterbeginn den Studierenden und Verlange die Organisation eines Kickoff-Meetings.</li>
+            <li>Schreibe bei Semesterbeginn den Studierenden und Verlange die Organisation eines Kickoff-Meetings oder organisiere das Kickoff-Meeting selbst.</li>
             <li>Informiere die Studierenden über folgende Punkte beim Kickoff-Meeting:
                 <ul>
                     <li>Information, dass pro Student/-in eine individuelle Note festgelegt wird.</li>
@@ -22,6 +22,7 @@
                         existiert nicht. Die Projektvereinbarung umfasst 1-2 Seiten und enthält folgende Punkte:
                         <ul>
                             <li>Wiedergabe der Ausgangslage und Aufgabenstellung in eigenen Worten</li>
+                            <li>Definition von Fragestellungen die mit diesem Projekt beantwortet werden sollen</li>
                             <li>Vorgehen mit grobem Zeitplan und Meilensteinen</li>
                             <li>Umgang mit Projektrisiken, falls nötig</li>
                         </ul>
@@ -31,10 +32,11 @@
             <li>Falls sich eine ungenügende Note abzeichnet, sind für den Rekursfall <a href="FAQ#rekurs">einige Dinge</a> zu beachten. Melde Dich möglichst früh bei uns.</li>
             <li>Nur für P6-Projekte: Titeländerungen können bis <%: (ProStudCreator.Global.AllowTitleChangesBeforeSubmission.Days/7) %> Wochen vor Abgabe auf der jeweiligen Projekt-Infoseite vorgenommen werden.</li>
             <li>Die Studierenden erstellen das obligatorische Websummary. Auf dem Netzwerkshare gibts dazu einen Leitfaden (\\fsemu18.edu.ds.fhnw.ch\e_18_data11$\E1811_Info\E1811_Info_I\Projektschiene).</li>
-            <li>Nur für Projekte, die im Herbst abschliessen: Die Studierenden stellen Ihr IP6 an der Ausstellung mit einem <a href="Content/Poster_TemplateI_150923.pptx" class="ppt">Poster</a> vor. Poster
+            <li>Die Studierenden stellen Ihr IP6 an der Ausstellung mit einem <a href="Content/Poster_TemplateI_150923.pptx" class="ppt">Poster</a> vor. Poster
                 können vom Empfang in A0-Grösse gedruckt werden.</li>
-            <li><ul>
-                    <li>IP5: Lasse die Studierenden ein Schlusspräsentation organisieren (Raum, Termin). Die Präsentation im IP5 wird verlangt, da sie der Vorbereitung auf die Schlusspräsentation und Verteidigung der Bachelorarbeit dient.</li>
+            <li>Schlusspräsentation:
+                <ul>
+                    <li>IP5: Lasse die Studierenden ein Schlusspräsentation organisieren (Raum, Termin) oder organisiere die Schlusspräsentation selbst. Die Präsentation im IP5 wird verlangt, da sie der Vorbereitung auf die Schlusspräsentation und Verteidigung der Bachelorarbeit dient.</li>
                     <li>IP6: Die Schlusspräsentation (Raum, Termin, Experte/-in) wird von uns organisiert. Details sind auf der Projekt-Infoseite ersichtlich. Die Studierenden schicken ihre Arbeit an den Experten, in elektronischer oder Papier-Form, je nach Wunsch des Experten.</li>
                 </ul>
             </li>
@@ -43,9 +45,11 @@
             <li>Schlusspräsentation mit ca. 30 Minuten Präsentation, und ca. 30 Minuten Fragen von Betreuern, Experten (IP6) und interessierten Gästen.</li>
             <li>Notenbesprechung mit den Experten (IP6), ggf. Anpassung der Bewertung. Pro Student/-in soll eine <i>individuelle</i> Note festgelegt werden. Noten >5.8 müssen an die SGL gemeldet werden.</li>
             <li>Auf der Projekt-Infoseite die Note, Verrechenbarkeit und Sprache des Projekts eintragen. Dort auch alle Projektartefakte (Doku, Code, ...) hochladen.</li>
-            <li><b>NEU: Zum Schluss das Projekt im ProStud abschliessen.</b></li>
-            <li>Den Bewertungsbogen den Studierenden schicken, aber ohne Kommentare (Spalte G).</li>
-            <li>NEU: Du machst mit den Studierenden eine Schlusssitzung. An der Sitzung soll die Bewertung besprochen und die Arbeit reflektiert werden, um den Lerneffekt zu erhöhen.</li>
+            <li>Zum Schluss das Projekt im ProStud abschliessen.</li>
+            <li>Du machst mit den Studierenden eine Schlusssitzung. An der Sitzung soll die Bewertung besprochen und die Arbeit reflektiert werden, um den Lerneffekt zu erhöhen.</li>
+            <li>Bei der Abschlussbesprechung der Arbeit wird das Blatt des Bewertungsbogens "1. Gesamtbewertung" (inkl. Würdigung) an die Studierenden abgegeben.
+                Blatt "2. Detailbewertung" des Bewertungsbogens wird ebenfalls an die Studierenden abgegeben, ggf. aber ohne die Kommentare (Spalte G). Die Teilnoten (Spalte D) werden abgegeben.
+            </li>
         </ol>
     </div>
 


### PR DESCRIPTION
An der letzten SGL (im März 2023) wurde festgelegt, dass auch im Frühling, d.h. bei der Abgabe der Bachelor-Projekte die im HS durchgeführt werdne eine Bachelor-Ausstellung stattfindet.

Zudem habe ich bei dieser Gelegenheit noch ein paar andere Punkte ergänzt bzw. präzisiert.

Die Terminliste https://www.cs.technik.fhnw.ch/prostud/Termine ist bereits nachgeführt.

Liebe Grüsse
Dominik
